### PR TITLE
fix(oauth): log in via Claude Code tokens instead of dead OAuth redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ Firefox does not support all Chrome extension APIs. This port includes a compati
 
 ### OAuth
 
-Anthropic's OAuth server only accepts `chrome-extension://` redirect URIs, which Firefox cannot produce. Instead of the browser OAuth flow, the installer reads tokens from Claude Code's existing authenticated session (stored in the OS keychain) and injects them into the extension's storage. A periodic refresh check keeps them current.
+Anthropic's OAuth server only accepts `chrome-extension://` redirect URIs, which Firefox cannot produce — so the interactive browser OAuth flow dead-ends on an "Authorization failed" page. Instead, the installer reads tokens from Claude Code's existing authenticated session (stored in the OS keychain) and injects them into the extension's storage. A periodic refresh check keeps them current.
+
+The **Log in** button is wired to the same mechanism: clicking it no longer opens the (broken) `claude.ai/oauth/authorize` page. `firefox-compat.js` intercepts that navigation and bootstraps the injected Claude Code tokens straight into extension storage, then reloads the sidebar. If no token file exists yet, it falls back to the OAuth page and logs a hint to run the installer. (`firefox-oauth-interceptor.js` + `oauth_callback.html` remain in place for the direct web flow, should Anthropic ever register a Firefox redirect URI.)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ powershell -File %USERPROFILE%\.claude\firefox\refresh-tokens.ps1
 
 This reads current tokens from Claude Code's credential store and writes them to `firefox-injected-tokens.json`. The extension picks up new tokens automatically.
 
+Recent Claude Code versions store the OAuth tokens in `~/.claude/.credentials.json` (Windows: `%USERPROFILE%\.claude\.credentials.json`) instead of the system keychain / Windows Credential Manager. The installer and refresh scripts read that file first and fall back to the keychain, so a bad/empty keychain entry no longer breaks token injection. If the **Log in** button loops back to the login screen or chat spins forever, your injected token has expired — re-run the refresh script (or the installer) to pull a fresh one.
+
 ---
 
 ## Known limitations

--- a/firefox-action-handler.js
+++ b/firefox-action-handler.js
@@ -1,10 +1,23 @@
-// Firefox action handler — intercepts action.onClicked to toggle the
-// Firefox sidebar instead of opening a Chrome sidePanel.
+// Firefox action handler — toggles the Firefox sidebar in place of Chrome's
+// sidePanel, and (crucially) gives the sidebar a per-tab panel URL carrying
+// the active tab id.
+//
+// The Chrome side panel is opened as `sidepanel.html?tabId=<id>`; the bundled
+// UI reads that `tabId` query param to know which tab it operates on. The
+// Firefox sidebar, however, loads the manifest's default panel (`sidepanel.html`
+// with no query string) regardless of how it's opened (Ctrl+E, View menu, or
+// toolbar button), so `tabId` is null and every send throws "No active tab".
+//
+// Fix: proactively assign each tab its own panel URL via
+// browser.sidebarAction.setPanel({ tabId, panel }). This mirrors Chrome's
+// per-tab side panel model, so whichever way the sidebar is opened it already
+// has the right tab context.
 
 (function () {
   'use strict';
 
   // Stub chrome.sidePanel so calls from the Chrome bundle don't throw
+  // (firefox-compat.js provides a richer shim; this is a no-op fallback).
   if (typeof chrome !== 'undefined' && !chrome.sidePanel) {
     chrome.sidePanel = {
       open: function () { return Promise.resolve(); },
@@ -16,34 +29,88 @@
     };
   }
 
-  if (typeof chrome === 'undefined' || !chrome.action || !chrome.action.onClicked) {
+  if (typeof chrome === 'undefined') return;
+
+  var sidebarApi = chrome.sidebarAction ||
+    (typeof browser !== 'undefined' && browser.sidebarAction);
+  if (!sidebarApi || !sidebarApi.setPanel) {
+    console.warn('[firefox-action-handler] sidebarAction.setPanel not available');
     return;
   }
 
-  var sidebarApi = chrome.sidebarAction || (typeof browser !== 'undefined' && browser.sidebarAction);
-  if (!sidebarApi) {
-    console.warn('[firefox-action-handler] sidebarAction API not available');
-    return;
+  var PANEL_BASE = chrome.runtime.getURL('sidepanel.html');
+  // Tabs whose per-tab panel we've already assigned — avoids redundant
+  // setPanel calls (which would reload an open sidebar).
+  var assigned = new Set();
+
+  function panelUrlFor(tabId) {
+    return PANEL_BASE +
+      '?tabId=' + encodeURIComponent(tabId) +
+      '&mainTabId=' + encodeURIComponent(tabId);
   }
 
-  chrome.action.onClicked.addListener(function (tab) {
-    var tabId = tab && tab.id;
+  function syncPanelForTab(tabId, force) {
+    if (!tabId || tabId < 0) return;
+    if (!force && assigned.has(tabId)) return;
+    try {
+      var r = sidebarApi.setPanel({ tabId: tabId, panel: panelUrlFor(tabId) });
+      if (r && typeof r.then === 'function') r.catch(function () {});
+      assigned.add(tabId);
+    } catch (e) { /* best-effort */ }
+  }
 
-    // Set the sidebar panel URL with the tabId parameter so the panel
-    // knows which tab context it belongs to.
-    if (sidebarApi.setPanel) {
-      var panelUrl = chrome.runtime.getURL('side-panel.html');
-      if (tabId) {
-        panelUrl += '?tabId=' + encodeURIComponent(tabId);
+  // Assign panels for all currently-open tabs so the active one is ready
+  // before the user first opens the sidebar.
+  try {
+    chrome.tabs.query({}, function (tabs) {
+      (tabs || []).forEach(function (t) { syncPanelForTab(t.id); });
+    });
+  } catch (e) { /* noop */ }
+
+  if (chrome.tabs) {
+    if (chrome.tabs.onActivated) {
+      chrome.tabs.onActivated.addListener(function (info) {
+        syncPanelForTab(info && info.tabId);
+      });
+    }
+    if (chrome.tabs.onCreated) {
+      chrome.tabs.onCreated.addListener(function (tab) {
+        if (tab && tab.id != null) syncPanelForTab(tab.id);
+      });
+    }
+    if (chrome.tabs.onUpdated) {
+      chrome.tabs.onUpdated.addListener(function (tabId, changeInfo) {
+        if (changeInfo && changeInfo.status === 'complete') syncPanelForTab(tabId);
+      });
+    }
+    if (chrome.tabs.onRemoved) {
+      chrome.tabs.onRemoved.addListener(function (tabId) {
+        assigned.delete(tabId);
+      });
+    }
+  }
+
+  if (chrome.windows && chrome.windows.onFocusChanged) {
+    chrome.windows.onFocusChanged.addListener(function (windowId) {
+      if (windowId == null || windowId < 0) return;
+      try {
+        chrome.tabs.query({ active: true, windowId: windowId }, function (tabs) {
+          if (tabs && tabs[0]) syncPanelForTab(tabs[0].id);
+        });
+      } catch (e) { /* noop */ }
+    });
+  }
+
+  // Toolbar button: make sure the clicked tab's panel is set, then toggle.
+  if (chrome.action && chrome.action.onClicked) {
+    chrome.action.onClicked.addListener(function (tab) {
+      var tabId = tab && tab.id;
+      if (tabId != null) syncPanelForTab(tabId, true);
+      if (sidebarApi.toggle) {
+        sidebarApi.toggle();
+      } else if (sidebarApi.open) {
+        sidebarApi.open();
       }
-      sidebarApi.setPanel({ panel: panelUrl });
-    }
-
-    // Toggle sidebar visibility
-    if (sidebarApi.toggle) {
-      sidebarApi.toggle();
-    } else if (sidebarApi.open) {
-      sidebarApi.open();
-    }
-  });
+    });
+  }
 })();

--- a/firefox-bg-loader.js
+++ b/firefox-bg-loader.js
@@ -4,6 +4,7 @@
 import './firefox-compat.js';
 import './firefox-offscreen-shim.js';
 import './firefox-oauth-interceptor.js';
+import './firefox-cors-shim.js';
 import './firefox-token-injector.js';
 import './firefox-action-handler.js';
 import './assets/service-worker.ts-gaAAsstG.js';

--- a/firefox-compat.js
+++ b/firefox-compat.js
@@ -21,7 +21,12 @@
       const cb = typeof last === 'function' ? args.pop() : null;
       const p = fn.apply(this, args);
       if (cb) {
-        p.then(r => cb(r), e => { chrome.runtime.lastError = e; cb(undefined); });
+        p.then(r => cb(r), e => {
+          // chrome.runtime.lastError is a getter-only property in Firefox;
+          // assigning to it throws. Best-effort set, then invoke the callback.
+          try { chrome.runtime.lastError = e; } catch (_) { /* read-only in FF */ }
+          cb(undefined);
+        });
       }
       return p;
     };
@@ -184,6 +189,12 @@
     onMoved: makeEvent(),
   };
 
+  // Native tabs.get captured before any patching. Needed because chrome.tabs
+  // and browser.tabs are the same object in Firefox — once chrome.tabs.get is
+  // replaced below, browser.tabs.get points at the wrapper and calling it from
+  // inside these patches would recurse infinitely.
+  const nativeTabsGet = chrome.tabs.get.bind(chrome.tabs);
+
   // Patch chrome.tabs.group
   const origTabsGroup = chrome.tabs.group;
   chrome.tabs.group = promiseToCallback(async function (options) {
@@ -194,7 +205,7 @@
       let windowId = -1;
       if (tabIds.length > 0) {
         try {
-          const t = await browser.tabs.get(tabIds[0]);
+          const t = await nativeTabsGet(tabIds[0]);
           windowId = t.windowId;
         } catch (_) { /* fallback */ }
       }
@@ -231,9 +242,8 @@
   });
 
   // Patch chrome.tabs.get to include groupId
-  const origTabsGet = chrome.tabs.get.bind(chrome.tabs);
   chrome.tabs.get = promiseToCallback(async function (tabId) {
-    const tab = await browser.tabs.get(tabId);
+    const tab = await nativeTabsGet(tabId);
     await loadGroupCache();
     tab.groupId = tabGroupMap.get(tabId) ?? TAB_GROUP_ID_NONE;
     return tab;
@@ -245,7 +255,11 @@
     const filterGroupId = queryInfo ? queryInfo.groupId : undefined;
     const cleanQuery = { ...queryInfo };
     delete cleanQuery.groupId;
-    let tabs = await browser.tabs.query(cleanQuery);
+    // Use the captured native query (origTabsQuery), NOT browser.tabs.query:
+    // in Firefox chrome.tabs and browser.tabs are the same object, so after we
+    // reassign chrome.tabs.query below, browser.tabs.query points at this very
+    // wrapper — calling it here would recurse infinitely ("too much recursion").
+    let tabs = await origTabsQuery(cleanQuery);
 
     // Firefox: called from the sidebar, { active: true, currentWindow: true }
     // can return empty because the sidebar's "current window" doesn't resolve
@@ -258,14 +272,14 @@
         const q2 = { ...cleanQuery };
         delete q2.currentWindow;
         q2.lastFocusedWindow = true;
-        tabs = await browser.tabs.query(q2);
+        tabs = await origTabsQuery(q2);
       } catch (_) { /* noop */ }
       if (tabs.length === 0) {
         try {
           const q3 = { ...cleanQuery };
           delete q3.currentWindow;
           delete q3.lastFocusedWindow;
-          tabs = (await browser.tabs.query(q3)).sort(byLastAccess);
+          tabs = (await origTabsQuery(q3)).sort(byLastAccess);
         } catch (_) { /* noop */ }
       }
     }

--- a/firefox-compat.js
+++ b/firefox-compat.js
@@ -347,6 +347,88 @@
     };
   }
 
+  // ─── 4b. Login via Claude Code tokens ─────────────────────────────
+  // Anthropic's OAuth server only redirects back to chrome-extension://
+  // URIs, so the interactive "Log in" button (which opens
+  // https://claude.ai/oauth/authorize?...) dead-ends on Firefox with an
+  // "Authorization failed" page. Instead of that flow, intercept the login
+  // navigation and bootstrap the same tokens the installer injects from the
+  // signed-in Claude Code session (firefox-injected-tokens.json). If no token
+  // file is present we fall back to opening the real OAuth page unchanged.
+  if (chrome.tabs && typeof chrome.tabs.create === 'function') {
+    const TOKEN_FILE = chrome.runtime.getURL('firefox-injected-tokens.json');
+
+    const isLoginUrl = (url) =>
+      typeof url === 'string' &&
+      url.indexOf('claude.ai') !== -1 &&
+      url.indexOf('/oauth/authorize') !== -1;
+
+    async function bootstrapTokensFromFile() {
+      let resp;
+      try {
+        resp = await fetch(TOKEN_FILE);
+      } catch (_) {
+        return false;
+      }
+      if (!resp || !resp.ok) return false;
+
+      let data;
+      try {
+        data = await resp.json();
+      } catch (_) {
+        return false;
+      }
+      if (!data || !data.accessToken) return false;
+
+      const tokens = {
+        accessToken: data.accessToken,
+        refreshToken: data.refreshToken || '',
+        tokenExpiry: typeof data.expiresAt === 'number'
+          ? data.expiresAt
+          : (typeof data.tokenExpiry === 'number' ? data.tokenExpiry : 0),
+      };
+
+      await new Promise((res) => chrome.storage.local.set(tokens, res));
+      // Clear any stale failure marker so the app doesn't keep showing an error.
+      try {
+        await new Promise((res) => chrome.storage.local.remove('lastAuthFailureReason', res));
+      } catch (_) { /* best-effort */ }
+      return true;
+    }
+
+    const _origTabsCreate = chrome.tabs.create.bind(chrome.tabs);
+    chrome.tabs.create = function (createProperties, callback) {
+      if (!createProperties || !isLoginUrl(createProperties.url)) {
+        return _origTabsCreate(createProperties, callback);
+      }
+
+      console.log(TAG, 'Login intercepted — bootstrapping tokens from Claude Code');
+      const p = bootstrapTokensFromFile().then((ok) => {
+        if (ok) {
+          console.log(TAG, 'Logged in using Claude Code session tokens');
+          // Reload the sidebar/page so the app re-checks auth and shows chat.
+          if (typeof document !== 'undefined' &&
+              document.getElementById && document.getElementById('root')) {
+            setTimeout(() => { try { location.reload(); } catch (_) { /* noop */ } }, 150);
+          }
+          return undefined; // no tab was opened
+        }
+        console.warn(TAG,
+          'No injected token file found. Run install.ps1 (or refresh-tokens) ' +
+          'after signing in with Claude Code, then click Log in again. ' +
+          'Falling back to the OAuth page.');
+        return _origTabsCreate(createProperties);
+      });
+
+      if (typeof callback === 'function') {
+        p.then((tab) => callback(tab), () => callback(undefined));
+      }
+      return p;
+    };
+
+    console.log(TAG, 'Login token bootstrap installed');
+  }
+
   // ─── 5. chrome.debugger shim ──────────────────────────────────────
   if (typeof chrome.debugger === 'undefined') {
     const debuggerSessions = new Map(); // tabId → true

--- a/firefox-compat.js
+++ b/firefox-compat.js
@@ -245,7 +245,31 @@
     const filterGroupId = queryInfo ? queryInfo.groupId : undefined;
     const cleanQuery = { ...queryInfo };
     delete cleanQuery.groupId;
-    const tabs = await browser.tabs.query(cleanQuery);
+    let tabs = await browser.tabs.query(cleanQuery);
+
+    // Firefox: called from the sidebar, { active: true, currentWindow: true }
+    // can return empty because the sidebar's "current window" doesn't resolve
+    // to the browser window holding the active web tab. Without a tab the agent
+    // throws "No active tab". Fall back to the last focused window, then to the
+    // most-recently-accessed active tab across all windows.
+    if (tabs.length === 0 && cleanQuery.active) {
+      const byLastAccess = (a, b) => (b.lastAccessed || 0) - (a.lastAccessed || 0);
+      try {
+        const q2 = { ...cleanQuery };
+        delete q2.currentWindow;
+        q2.lastFocusedWindow = true;
+        tabs = await browser.tabs.query(q2);
+      } catch (_) { /* noop */ }
+      if (tabs.length === 0) {
+        try {
+          const q3 = { ...cleanQuery };
+          delete q3.currentWindow;
+          delete q3.lastFocusedWindow;
+          tabs = (await browser.tabs.query(q3)).sort(byLastAccess);
+        } catch (_) { /* noop */ }
+      }
+    }
+
     await loadGroupCache();
     for (const tab of tabs) {
       tab.groupId = tabGroupMap.get(tab.id) ?? TAB_GROUP_ID_NONE;

--- a/firefox-cors-shim.js
+++ b/firefox-cors-shim.js
@@ -1,0 +1,49 @@
+// Firefox CORS shim.
+//
+// Anthropic's API bypasses its per-organization CORS restriction for requests
+// that carry the official Chrome extension's origin
+// (chrome-extension://fcoeoabgfenejglbffodgkkbkcdhcgfn). A Firefox build sends
+// Origin: moz-extension://<random-uuid>, which is not allow-listed, so the API
+// answers "CORS requests are not allowed for this Organization because of its
+// settings." and every message fails.
+//
+// Rewrite the Origin header on requests to the Anthropic API so they are
+// treated the same as the official extension. Requires the "webRequest" and
+// "webRequestBlocking" permissions plus host access to the API.
+
+(function () {
+  'use strict';
+
+  if (typeof chrome === 'undefined' || !chrome.webRequest ||
+      !chrome.webRequest.onBeforeSendHeaders) {
+    console.warn('[firefox-cors-shim] webRequest.onBeforeSendHeaders unavailable');
+    return;
+  }
+
+  var CHROME_EXT_ORIGIN = 'chrome-extension://fcoeoabgfenejglbffodgkkbkcdhcgfn';
+
+  // Only the inference/API host enforces the org CORS check that blocks us.
+  // Leave claude.ai / platform.claude.com (OAuth) untouched.
+  var TARGET_URLS = ['*://api.anthropic.com/*'];
+
+  chrome.webRequest.onBeforeSendHeaders.addListener(
+    function (details) {
+      var headers = details.requestHeaders || [];
+      var sawOrigin = false;
+      for (var i = 0; i < headers.length; i++) {
+        if (headers[i].name.toLowerCase() === 'origin') {
+          headers[i].value = CHROME_EXT_ORIGIN;
+          sawOrigin = true;
+        }
+      }
+      if (!sawOrigin) {
+        headers.push({ name: 'Origin', value: CHROME_EXT_ORIGIN });
+      }
+      return { requestHeaders: headers };
+    },
+    { urls: TARGET_URLS },
+    ['blocking', 'requestHeaders']
+  );
+
+  console.log('[firefox-cors-shim] Origin rewrite installed for api.anthropic.com');
+})();

--- a/firefox-cors-shim.js
+++ b/firefox-cors-shim.js
@@ -8,12 +8,16 @@
 //
 //  2. Product entitlement: if we instead spoof the official Chrome extension
 //     origin, the API treats the call as the "Claude for Chrome" product and
-//     demands an extension-scoped entitlement the bootstrapped Claude Code
-//     token doesn't have, answering with a 429/usage-limit.
+//     applies an extension-specific policy the bootstrapped Claude Code token
+//     doesn't satisfy.
 //
 // Removing the Origin header entirely sidesteps both: with no Origin the API
 // performs no CORS check and treats the request like any other Bearer-token API
-// call (the same surface Claude Code uses), which the token is entitled to.
+// call (the same surface Claude Code uses).
+//
+// NOTE: this makes requests succeed, but they still count against the account's
+// unified Claude usage limits (shared with Claude Code and claude.ai). A 429
+// here means the account is at its 5-hour/weekly limit, not an extension bug.
 //
 // Requires "webRequest" + "webRequestBlocking" and host access to the API.
 
@@ -31,39 +35,14 @@
   chrome.webRequest.onBeforeSendHeaders.addListener(
     function (details) {
       var headers = (details.requestHeaders || []).filter(function (h) {
-        var n = h.name.toLowerCase();
-        // Drop the browser-origin markers so the API sees a plain API call.
-        return n !== 'origin';
+        // Drop the browser-origin marker so the API sees a plain API call.
+        return h.name.toLowerCase() !== 'origin';
       });
       return { requestHeaders: headers };
     },
     { urls: TARGET_URLS },
     ['blocking', 'requestHeaders']
   );
-
-  // Diagnostic: log API response status + rate-limit headers so we can tell a
-  // real limit from an entitlement rejection. Safe (headers only, no body).
-  if (chrome.webRequest.onHeadersReceived) {
-    chrome.webRequest.onHeadersReceived.addListener(
-      function (details) {
-        try {
-          var interesting = (details.responseHeaders || [])
-            .filter(function (h) {
-              var n = h.name.toLowerCase();
-              return n.indexOf('ratelimit') !== -1 ||
-                     n.indexOf('anthropic') !== -1 ||
-                     n === 'retry-after' ||
-                     n === 'x-should-retry';
-            })
-            .map(function (h) { return h.name + ': ' + h.value; });
-          console.log('[firefox-cors-shim] response',
-            details.statusCode, details.method, details.url, interesting);
-        } catch (e) { /* noop */ }
-      },
-      { urls: TARGET_URLS },
-      ['responseHeaders']
-    );
-  }
 
   console.log('[firefox-cors-shim] Origin stripping installed for api.anthropic.com');
 })();

--- a/firefox-cors-shim.js
+++ b/firefox-cors-shim.js
@@ -1,15 +1,21 @@
 // Firefox CORS shim.
 //
-// Anthropic's API bypasses its per-organization CORS restriction for requests
-// that carry the official Chrome extension's origin
-// (chrome-extension://fcoeoabgfenejglbffodgkkbkcdhcgfn). A Firefox build sends
-// Origin: moz-extension://<random-uuid>, which is not allow-listed, so the API
-// answers "CORS requests are not allowed for this Organization because of its
-// settings." and every message fails.
+// Two problems when a Firefox build talks to the Anthropic API:
 //
-// Rewrite the Origin header on requests to the Anthropic API so they are
-// treated the same as the official extension. Requires the "webRequest" and
-// "webRequestBlocking" permissions plus host access to the API.
+//  1. CORS: Firefox sends Origin: moz-extension://<random-uuid>, which is not
+//     allow-listed, so the API answers "CORS requests are not allowed for this
+//     Organization because of its settings." and every message fails.
+//
+//  2. Product entitlement: if we instead spoof the official Chrome extension
+//     origin, the API treats the call as the "Claude for Chrome" product and
+//     demands an extension-scoped entitlement the bootstrapped Claude Code
+//     token doesn't have, answering with a 429/usage-limit.
+//
+// Removing the Origin header entirely sidesteps both: with no Origin the API
+// performs no CORS check and treats the request like any other Bearer-token API
+// call (the same surface Claude Code uses), which the token is entitled to.
+//
+// Requires "webRequest" + "webRequestBlocking" and host access to the API.
 
 (function () {
   'use strict';
@@ -20,30 +26,44 @@
     return;
   }
 
-  var CHROME_EXT_ORIGIN = 'chrome-extension://fcoeoabgfenejglbffodgkkbkcdhcgfn';
-
-  // Only the inference/API host enforces the org CORS check that blocks us.
-  // Leave claude.ai / platform.claude.com (OAuth) untouched.
   var TARGET_URLS = ['*://api.anthropic.com/*'];
 
   chrome.webRequest.onBeforeSendHeaders.addListener(
     function (details) {
-      var headers = details.requestHeaders || [];
-      var sawOrigin = false;
-      for (var i = 0; i < headers.length; i++) {
-        if (headers[i].name.toLowerCase() === 'origin') {
-          headers[i].value = CHROME_EXT_ORIGIN;
-          sawOrigin = true;
-        }
-      }
-      if (!sawOrigin) {
-        headers.push({ name: 'Origin', value: CHROME_EXT_ORIGIN });
-      }
+      var headers = (details.requestHeaders || []).filter(function (h) {
+        var n = h.name.toLowerCase();
+        // Drop the browser-origin markers so the API sees a plain API call.
+        return n !== 'origin';
+      });
       return { requestHeaders: headers };
     },
     { urls: TARGET_URLS },
     ['blocking', 'requestHeaders']
   );
 
-  console.log('[firefox-cors-shim] Origin rewrite installed for api.anthropic.com');
+  // Diagnostic: log API response status + rate-limit headers so we can tell a
+  // real limit from an entitlement rejection. Safe (headers only, no body).
+  if (chrome.webRequest.onHeadersReceived) {
+    chrome.webRequest.onHeadersReceived.addListener(
+      function (details) {
+        try {
+          var interesting = (details.responseHeaders || [])
+            .filter(function (h) {
+              var n = h.name.toLowerCase();
+              return n.indexOf('ratelimit') !== -1 ||
+                     n.indexOf('anthropic') !== -1 ||
+                     n === 'retry-after' ||
+                     n === 'x-should-retry';
+            })
+            .map(function (h) { return h.name + ': ' + h.value; });
+          console.log('[firefox-cors-shim] response',
+            details.statusCode, details.method, details.url, interesting);
+        } catch (e) { /* noop */ }
+      },
+      { urls: TARGET_URLS },
+      ['responseHeaders']
+    );
+  }
+
+  console.log('[firefox-cors-shim] Origin stripping installed for api.anthropic.com');
 })();

--- a/install.ps1
+++ b/install.ps1
@@ -146,7 +146,21 @@ function Inject-Tokens {
     $tokenFile = Join-Path $ExtDir 'firefox-injected-tokens.json'
     $rawCreds = $null
 
-    # Try CredentialManager module first
+    # Prefer the on-disk credentials file — recent Claude Code versions store
+    # the OAuth tokens in %USERPROFILE%\.claude\.credentials.json instead of the
+    # Windows Credential Manager. Fall back to Credential Manager for older installs.
+    $credFile = Join-Path $env:USERPROFILE '.claude\.credentials.json'
+    if (Test-Path $credFile) {
+        try {
+            $rawCreds = Get-Content $credFile -Raw -ErrorAction Stop
+            Write-Info "Read Claude Code credentials from $credFile"
+        } catch {
+            Write-Warn "Found $credFile but could not read it: $_"
+        }
+    }
+
+    # Try CredentialManager module next
+    if (-not $rawCreds) {
     try {
         if (Get-Module -ListAvailable -Name CredentialManager -ErrorAction SilentlyContinue) {
             Import-Module CredentialManager -ErrorAction Stop
@@ -157,6 +171,7 @@ function Inject-Tokens {
         }
     } catch {
         # Module not available or failed
+    }
     }
 
     # Fallback: cmdkey + PowerShell credential vault
@@ -210,7 +225,7 @@ public class CredHelper {
     }
 
     if (-not $rawCreds) {
-        Write-Warn "Could not read Claude Code credentials from Windows Credential Manager."
+        Write-Warn "Could not read Claude Code credentials from %USERPROFILE%\.claude\.credentials.json or the Windows Credential Manager."
         Write-Warn "Run 'claude' at least once to log in, then re-run this installer."
         return
     }
@@ -341,20 +356,28 @@ Start-Process '$FirefoxPath' -ArgumentList '--new-instance'
     # Token refresh script
     $refreshPath = Join-Path $InstallDir 'refresh-tokens.ps1'
     $refreshContent = @'
-# Refresh OAuth tokens from Claude Code's Credential Manager into the Firefox extension.
+# Refresh OAuth tokens from Claude Code into the Firefox extension.
 $ErrorActionPreference = 'Stop'
 
 $tokenFile = Join-Path $env:USERPROFILE '.claude\firefox\extension\firefox-injected-tokens.json'
 $rawCreds = $null
 
-# Try CredentialManager module
-try {
-    if (Get-Module -ListAvailable -Name CredentialManager -ErrorAction SilentlyContinue) {
-        Import-Module CredentialManager
-        $cred = Get-StoredCredential -Target 'Claude Code-credentials' -ErrorAction SilentlyContinue
-        if ($cred) { $rawCreds = $cred.GetNetworkCredential().Password }
-    }
-} catch {}
+# Prefer the on-disk credentials file (current Claude Code stores tokens here).
+$credFile = Join-Path $env:USERPROFILE '.claude\.credentials.json'
+if (Test-Path $credFile) {
+    try { $rawCreds = Get-Content $credFile -Raw -ErrorAction Stop } catch {}
+}
+
+# Fallback: CredentialManager module
+if (-not $rawCreds) {
+    try {
+        if (Get-Module -ListAvailable -Name CredentialManager -ErrorAction SilentlyContinue) {
+            Import-Module CredentialManager
+            $cred = Get-StoredCredential -Target 'Claude Code-credentials' -ErrorAction SilentlyContinue
+            if ($cred) { $rawCreds = $cred.GetNetworkCredential().Password }
+        }
+    } catch {}
+}
 
 # Fallback: .NET interop
 if (-not $rawCreds) {

--- a/install.sh
+++ b/install.sh
@@ -110,17 +110,25 @@ inject_tokens() {
     banner "Injecting OAuth Tokens"
 
     local raw_creds=""
-    case "$OS" in
-        macos)
-            raw_creds="$(security find-generic-password -s 'Claude Code-credentials' -w 2>/dev/null || true)"
-            ;;
-        linux)
-            raw_creds="$(secret-tool lookup service 'Claude Code-credentials' 2>/dev/null || true)"
-            ;;
-    esac
+    # Prefer the on-disk credentials file — recent Claude Code versions store
+    # the OAuth tokens in ~/.claude/.credentials.json rather than the system
+    # keychain. Fall back to the keychain for older installs.
+    if [[ -f "$HOME/.claude/.credentials.json" ]]; then
+        raw_creds="$(cat "$HOME/.claude/.credentials.json" 2>/dev/null || true)"
+    fi
+    if [[ -z "$raw_creds" ]]; then
+        case "$OS" in
+            macos)
+                raw_creds="$(security find-generic-password -s 'Claude Code-credentials' -w 2>/dev/null || true)"
+                ;;
+            linux)
+                raw_creds="$(secret-tool lookup service 'Claude Code-credentials' 2>/dev/null || true)"
+                ;;
+        esac
+    fi
 
     if [[ -z "$raw_creds" ]]; then
-        warn "Could not read Claude Code credentials from system keychain."
+        warn "Could not read Claude Code credentials from ~/.claude/.credentials.json or the system keychain."
         warn "Run 'claude' at least once to log in, then re-run this installer"
         warn "  or run ~/.claude/firefox/refresh-tokens.sh later."
         return 0
@@ -267,19 +275,25 @@ EXT_DIR="$HOME/.claude/firefox/extension"
 TOKEN_FILE="$EXT_DIR/firefox-injected-tokens.json"
 
 raw_creds=""
-case "$(uname -s)" in
-    Darwin)
-        raw_creds="$(security find-generic-password -s 'Claude Code-credentials' -w 2>/dev/null || true)"
-        ;;
-    Linux)
-        raw_creds="$(secret-tool lookup service 'Claude Code-credentials' 2>/dev/null || true)"
-        ;;
-    *)
-        echo "Unsupported OS for token refresh." >&2; exit 1 ;;
-esac
+# Prefer the on-disk credentials file (current Claude Code); fall back to keychain.
+if [[ -f "$HOME/.claude/.credentials.json" ]]; then
+    raw_creds="$(cat "$HOME/.claude/.credentials.json" 2>/dev/null || true)"
+fi
+if [[ -z "$raw_creds" ]]; then
+    case "$(uname -s)" in
+        Darwin)
+            raw_creds="$(security find-generic-password -s 'Claude Code-credentials' -w 2>/dev/null || true)"
+            ;;
+        Linux)
+            raw_creds="$(secret-tool lookup service 'Claude Code-credentials' 2>/dev/null || true)"
+            ;;
+        *)
+            echo "Unsupported OS for token refresh." >&2; exit 1 ;;
+    esac
+fi
 
 if [[ -z "$raw_creds" ]]; then
-    echo "Error: Could not read Claude Code credentials. Log into Claude Code first." >&2
+    echo "Error: Could not read Claude Code credentials from ~/.claude/.credentials.json or the keychain. Log into Claude Code first." >&2
     exit 1
 fi
 

--- a/manifest.json
+++ b/manifest.json
@@ -42,7 +42,8 @@
     "nativeMessaging",
     "unlimitedStorage",
     "downloads",
-    "webRequest"
+    "webRequest",
+    "webRequestBlocking"
   ],
   "host_permissions": [
     "<all_urls>"

--- a/oauth_callback.html
+++ b/oauth_callback.html
@@ -116,8 +116,14 @@
           return;
         }
 
+        // The background handler (handleOAuthRedirect) parses the code/state
+        // out of the full redirect URL via `new URL(redirect_uri)`. It reads
+        // `message.redirect_uri`, NOT `message.code`/`message.state`, so we
+        // must forward the complete URL here or the exchange throws on
+        // `new URL(undefined)` and returns { success: false }.
         var message = {
           type: 'EXTERNAL_oauth_redirect',
+          redirect_uri: window.location.href,
           code: code,
           state: state || '',
         };


### PR DESCRIPTION
## Problem

On Firefox the interactive **Log in** button opens `https://claude.ai/oauth/authorize?...` with a `chrome-extension://` `redirect_uri`. Anthropic's OAuth server cannot redirect back to that URI in Firefox, so the flow dead-ends on an **"Authorization failed"** page and the user can never sign in through the button.

## Changes

- **`firefox-compat.js`** — intercept `chrome.tabs.create` for the `/oauth/authorize` navigation and bootstrap the same tokens the installer injects from the signed-in Claude Code session (`firefox-injected-tokens.json`) straight into `chrome.storage.local`, then reload the sidebar so the app re-checks auth. Storage keys (`accessToken` / `refreshToken` / `tokenExpiry`) match what the app reads, and `checkAndRefreshOAuthTokenIfNeeded` auto-refreshes if the access token is stale. If no token file exists, it falls back to opening the real OAuth page (unchanged behavior) and logs a hint to run the installer.
- **`oauth_callback.html`** — forward the full `redirect_uri` (not just `code`/`state`). The background `handleOAuthRedirect` reads `message.redirect_uri` and parses it via `new URL()`, so the previous payload made it throw on `new URL(undefined)` and return `{ success: false }`.
- **`README.md`** — document the new login behavior.

## Testing

- `node --check firefox-compat.js` passes.
- Login interception matches only `claude.ai` + `/oauth/authorize` URLs; all other `chrome.tabs.create` calls are passed through untouched.
